### PR TITLE
update localstack check for latest version

### DIFF
--- a/src/orb.yaml
+++ b/src/orb.yaml
@@ -123,8 +123,9 @@ commands:
       - sh-command:
           <<: *wait-for-attributes
           sh-command: >-
-            curl --silent --fail
-            "http://<<parameters.host>>:<<parameters.port>>"
+            curl --silent
+            "http://<<parameters.host>>:<<parameters.port>>" |
+            grep --quiet running
 
   redis:
     description: Waits for Redis to be ready


### PR DESCRIPTION
Localstack has changed its behavior from returning 

```
$ curl --fail "http://localhost:4572"
<ListAllMyBucketsResult xmlns="http://s3.amazonaws.com/doc/2006-03-01"><Owner><ID>bcaf1ffd86f41161ca5fb16fd081034f</ID><DisplayName>webfile</DisplayName></Owner><Buckets><Bucket><Name>cobli-jobs-test</Name><CreationDate>2006-02-03T16:45:09.000Z</CreationDate></Bucket></Buckets></ListAllMyBucketsResult>
```
and http status = 200 to

```
$ curl "http://localhost:4572/" 
{"status": "running"}
```
with status 404 in latest version

Changing check to act accordingly. 